### PR TITLE
Debug django channels setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s CMD curl -f http://lo
 
 RUN uv add watchfiles
 
-CMD ["uv", "run", "python", "manage.py", "runserver_plus", "0.0.0.0:${WEB_PORT:-8000}", "--reload", "--reloader", "watchfiles"]
+CMD ["uv", "run", "daphne", "-b", "0.0.0.0", "-p", "${WEB_PORT:-8000}", "config.asgi:application"]
 


### PR DESCRIPTION
Switch Docker CMD to use Daphne to enable Django Channels (WebSocket) support.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa28c675-5f69-4dbf-8dbd-6a3bb230c244">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa28c675-5f69-4dbf-8dbd-6a3bb230c244">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

